### PR TITLE
defaultRenderFunction parameters don't match those passed from processData

### DIFF
--- a/jquery.awesomecomplete.js
+++ b/jquery.awesomecomplete.js
@@ -285,12 +285,12 @@
     };
 
 // default functions
-    var defaultRenderFunction = function(dataItem, topMatch, config)
+    var defaultRenderFunction = function(dataItem, topMatch, originalDataItem, config)
     {
         if ((topMatch === config.nameField) || (topMatch === null))
-            return '<p class="title">' + dataItem['name'] + '</p>';
+            return '<p class="title">' + dataItem[config.nameField] + '</p>';
         else
-            return '<p class="title">' + dataItem['name'] + '</p>' +
+            return '<p class="title">' + dataItem[config.nameField] + '</p>' +
                    '<p class="matchRow"><span class="matchedField">' + topMatch + '</span>: ' +
                         dataItem[topMatch] + '</p>';
     };


### PR DESCRIPTION
processData passes four parameters, where as defaultRenderFunction only accepts 3 - it's missing the originalDataItem parameter. It also uses the hard-coded nameField 'name' so that should be switched out to use the config value.
