### PR TITLE
Add support for clipping the result list and scrolling the selected item into view

### DIFF
--- a/jquery.awesomecomplete.js
+++ b/jquery.awesomecomplete.js
@@ -7,7 +7,8 @@
 
 (function($)
 {
-    var ident = 0;
+    var ident = 0,
+        scrollIntoView = ('scrollIntoView' in document.createElement('li'));
 
     // Initializer. Call on a text field to make things go.
     $.fn.awesomecomplete = function(options)
@@ -98,6 +99,12 @@
                         $list.hide();
                         suppressKey = true;
                         break;
+                }
+                if (scrollIntoView && $list.is(':visible')) {
+                    var $active = $list.children('li.' + config.activeItemClass);
+                    if ($active.length > 0) {
+                        $active.get(0).scrollIntoView(false);
+                    }
                 }
             });
 


### PR DESCRIPTION
Instead of getting a really long list of results that possibly extend over the screen it should be possibly to clip the result box. If you set a "max-height" and the "overflow" attribute to "auto" you will get just that. Awesomecomplete will however not understand that, which becomes clear when you navigate with the keyboard to an item outside the view.

By leveraging "scrollIntoView" only a few lines of code will take care of that for us. Most browsers have that function, though I don't know about cellphones and pads, so I added a check for it.
