### PR TITLE
Enhance the onComplete callback with the input element.

### DIFF
--- a/jquery.awesomecomplete.js
+++ b/jquery.awesomecomplete.js
@@ -73,7 +73,7 @@
                         {
                             event.preventDefault();
                             $this.val($active.data('awesomecomplete-value'));
-                            config.onComplete($active.data('awesomecomplete-dataItem'));
+                            config.onComplete($active.data('awesomecomplete-dataItem'), $this);
                             $list.hide();
                         }
                         $list.hide();
@@ -286,7 +286,7 @@
                 {
                     var $listItem = $(this);
                     $this.val($listItem.data('awesomecomplete-value'));
-                    config.onComplete($listItem.data('awesomecomplete-dataItem'));
+                    config.onComplete($listItem.data('awesomecomplete-dataItem'), $this);
                 })
                 .mouseover(function()
                 {
@@ -337,7 +337,7 @@
         nameField: 'name',
         noResultsClass: 'noResults',
         noResultsMessage: undefined,
-        onComplete: function(dataItem) {},
+        onComplete: function(dataItem, elem) {},
         sortFunction: defaultSortFunction,
         splitTerm: true,
         staticData: [],


### PR DESCRIPTION
I have a page with multiple input elements that are being enhanced by awesomecomplete. To be able to detect when the value has changed I needed to enhance the onComplete callback. By adding a second parameter carrying the input element I can tell which input field has (possibly) been changed.
